### PR TITLE
Add license header to all the source files.

### DIFF
--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/Exceptions/PrimExporterPermissionException.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/Exceptions/PrimExporterPermissionException.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ExpLib.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ExpLib.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/GroupDisplayData.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/GroupDisplayData.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/GroupLoader.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/GroupLoader.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using OpenMetaverse;
 using OpenSim.Framework;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/BabylonJSONFormatter.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/BabylonJSONFormatter.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Text;
 using ServiceStack.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/BabylonJSONPackager.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/BabylonJSONPackager.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/BabylonJSONPrimFaceCombiner.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/BabylonJSONPrimFaceCombiner.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenMetaverse;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/BabylonOutputs.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/BabylonOutputs.cs
@@ -1,4 +1,17 @@
-﻿using OpenMetaverse;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using OpenMetaverse;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ExportFormatterFactory.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ExportFormatterFactory.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ExportResult.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ExportResult.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ExportStats.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ExportStats.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/IExportFormatter.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/IExportFormatter.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/IPackager.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/IPackager.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/Package.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/Package.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/PackagerFactory.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/PackagerFactory.cs
@@ -1,4 +1,17 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System.Collections.Generic;
 
 namespace InWorldz.PrimExporter.ExpLib.ImportExport
 {

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/PackagerParams.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/PackagerParams.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ThreeJSONFormatter.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ThreeJSONFormatter.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Text;
 using ServiceStack.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ThreeJSONPackager.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ThreeJSONPackager.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ThreeJSONPrimFaceCombiner.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/ThreeJSONPrimFaceCombiner.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 
 namespace InWorldz.PrimExporter.ExpLib.ImportExport

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/TrackedTexture.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ImportExport/TrackedTexture.cs
@@ -1,4 +1,17 @@
-﻿namespace InWorldz.PrimExporter.ExpLib.ImportExport
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+namespace InWorldz.PrimExporter.ExpLib.ImportExport
 {
     internal class TrackedTexture
     {

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ObjectHasher.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/ObjectHasher.cs
@@ -1,3 +1,16 @@
+// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 using System;
 using OpenMetaverse;
 using OpenMetaverse.Rendering;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/PrimDisplayData.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/PrimDisplayData.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/PrimFace/FaceData.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/PrimFace/FaceData.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/PrimFace/TextureInfo.cs
+++ b/InWorldz.PrimExporter/InWorldz.PrimExporter.ExpLib/PrimFace/TextureInfo.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2016 InWorldz Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
This adds the short-form Apache 2.0 copyright header to the front of most of the CS files. No functional changes.